### PR TITLE
Remove trailing ?>

### DIFF
--- a/examples/custom.php
+++ b/examples/custom.php
@@ -9,4 +9,4 @@ $dh->addFormat(PHP_INT_MAX, 'long long ago', 1);
 
 echo $dh->get(time() - 60 * 4) . "\n"; //shows "< 5m"
 echo $dh->get(time() - 60 * 40) . "\n"; //shows "4 x 10 minutes ago"
-?>
+

--- a/examples/human.php
+++ b/examples/human.php
@@ -8,4 +8,4 @@ echo $dh->get(time() - 60 * 5) . "\n"; //shows "5 minutes ago"
 
 echo $dh->get(-3600, 0) . "\n"; //shows "an hour ago"
 
-?>
+

--- a/examples/translation.php
+++ b/examples/translation.php
@@ -7,4 +7,4 @@ $dh->setLanguage('de');
 // $dh->setLanguage('de_AT');//falls back to the "de" language
 
 echo $dh->get(time() - 60 * 5) . "\n"; //shows "vor 5 Minuten"
-?>
+

--- a/src/Date/HumanDiff.php
+++ b/src/Date/HumanDiff.php
@@ -275,4 +275,4 @@ class Date_HumanDiff
     }
 }
 
-?>
+

--- a/src/Date/HumanDiff/Lang.php
+++ b/src/Date/HumanDiff/Lang.php
@@ -12,4 +12,4 @@ interface Date_HumanDiff_Lang
     public function get($string);
 }
 
-?>
+

--- a/src/Date/HumanDiff/Lang/de.php
+++ b/src/Date/HumanDiff/Lang/de.php
@@ -25,4 +25,4 @@ class Date_HumanDiff_Lang_de extends Date_HumanDiff_LangArray
         '%d years ago'   => 'vor %d Jahren',
     );
 }
-?>
+

--- a/src/Date/HumanDiff/Lang/el.php
+++ b/src/Date/HumanDiff/Lang/el.php
@@ -25,4 +25,4 @@ class Date_HumanDiff_Lang_el extends Date_HumanDiff_LangArray
         '%d years ago'   => 'πριν %d χρόνια',
     );
 }
-?>
+

--- a/src/Date/HumanDiff/LangArray.php
+++ b/src/Date/HumanDiff/LangArray.php
@@ -20,4 +20,4 @@ abstract class Date_HumanDiff_LangArray implements Date_HumanDiff_Lang
     }
 }
 
-?>
+

--- a/tests/AllTests.php
+++ b/tests/AllTests.php
@@ -29,4 +29,3 @@ class Date_Human_DiffAllTests
 if (PHPUnit_MAIN_METHOD == 'Date_Human_DiffAllTests::main') {
     Date_Human_DiffAllTests::main();
 }
-?>

--- a/tests/Date/HumanDiff/LangArrayTest.php
+++ b/tests/Date/HumanDiff/LangArrayTest.php
@@ -20,4 +20,4 @@ class Date_HumanDiff_LangArrayTest extends PHPUnit_Framework_TestCase
     }
 }
 
-?>
+

--- a/tests/Date/HumanDiffTest.php
+++ b/tests/Date/HumanDiffTest.php
@@ -146,4 +146,4 @@ class Date_HumanDiffTest extends PHPUnit_Framework_TestCase
     }
 }
 
-?>
+


### PR DESCRIPTION
This removes the trailing ?> on all .php files.
